### PR TITLE
merge VMS and VVO endpoints together

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ There is a list of known endpoints (will be updated continuously with each relea
   </tr>
   <tr><td colspan="2" style="background:#5D8736" align="center"><b>Sachsen</b></td></tr>
   <tr>
-    <td><a href="https://efa.vvo-online.de/VMSSL3/">Verkehrsverbund Mittelsachsen GmbH (VMS)</a></td>
+    <td><a href="https://efa.vvo-online.de/std3/">Der Verkehrsverbund Oberelbe/Mittelsachsen (VVO/VMS)</a></td>
     <td align="center">Yes</td>
   </tr>
 </table>

--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -42,7 +42,7 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for ha_departures."""
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     def __init__(self) -> None:
         """Initialize."""

--- a/custom_components/ha_departures/const.py
+++ b/custom_components/ha_departures/const.py
@@ -68,7 +68,7 @@ EFA_ENDPOINTS: Final = {
     # Rheinland-Pfalz
     "Rolph.de": "https://mandanten.vrn.de/takt2/",
     # Sachsen
-    "Verkehrsverbund Mittelsachsen GmbH (VMS)": "https://efa.vvo-online.de/VMSSL3/",
+    "Der Verkehrsverbund Oberelbe/Mittelsachsen (VVO/VMS)": "https://efa.vvo-online.de/std3/",
     # Niedersachsen
     "Vehrkehrsverbund Region Braunschweig (VRB)": "https://bsvg.efa.de/vrbstd_relaunch/",
 }


### PR DESCRIPTION
- merge both endpoints in one "Der Verkehrsverbund Oberelbe/Mittelsachsen (VVO/VMS)"
- bump config enty minor version
- implement migration to 1.3 config flow version
- reorganize super() call in DeparturesDataUpdateCoordinator.__init__() and extend with config_entry argument