### PR TITLE
- fetch available lines before start options flow

### DIFF
--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -23,7 +23,6 @@ from .const import (
     CONF_AVAILABLE_LINES,
     CONF_ERROR_CONNECTION_FAILED,
     CONF_ERROR_INVALID_RESPONSE,
-    CONF_ERROR_NO_CHANGES_OPTIONS,
     CONF_ERROR_NO_LINE_SELECTED,
     CONF_ERROR_NO_STOP_FOUND,
     CONF_HUB_NAME,
@@ -54,6 +53,26 @@ async def _send_api_request(api: MotisApi, command, params):
         error = CONF_ERROR_CONNECTION_FAILED
 
     raise ValueError(error)
+
+
+def _extract_lines_from_stop_times(
+    stop_times_data: dict[str, Any], unique: bool = True
+) -> list[Line]:
+    """Extract unique lines from stop times data."""
+    lines: list[Line] = []
+
+    for stop_time in stop_times_data.get("stopTimes", []):
+        line = Line(
+            route_id=stop_time.get("routeId"),
+            direction_id=stop_time.get("directionId"),
+            head_sign=stop_time.get("headsign"),
+            route_short_name=stop_time.get("routeShortName"),
+            mode=TransportMode(stop_time.get("mode")),
+        )
+
+        lines.append(line)
+
+    return list(set(lines)) if unique else lines
 
 
 class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -214,8 +233,9 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 selected_lines.append(
                     next(
                         filter(
-                            lambda x: x.route_id == routeId
-                            and x.direction_id == directionId,
+                            lambda x: (
+                                x.route_id == routeId and x.direction_id == directionId
+                            ),
                             self._lines,
                         )
                     )
@@ -251,29 +271,15 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         "n": str(1000),
                     },
                 )
+
+                self._lines.extend(_extract_lines_from_stop_times(stop_times))
             except ValueError as err:
                 _errors[CONF_LOCATION] = str(err)
-
-            data = stop_times.get("stopTimes", [])
-
-            for stop_time in data:
-                line = Line(
-                    route_id=stop_time.get("routeId"),
-                    direction_id=stop_time.get("directionId"),
-                    head_sign=stop_time.get("headsign"),
-                    route_short_name=stop_time.get("routeShortName"),
-                    mode=TransportMode(stop_time.get("mode")),
+                _LOGGER.error(
+                    "Error fetching stop times for stop %s: %s, continuing with next stop if available",
+                    stop.id,
+                    err,
                 )
-
-                _LOGGER.debug(
-                    "Found line: [%s-%s] %s (%s)",
-                    line.mode,
-                    line.head_sign,
-                    line.route_short_name,
-                    line.direction_id,
-                )
-
-                self._lines.append(line)
 
         self._lines = list(set(self._lines))  # remove duplicate lines
 
@@ -368,34 +374,7 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
         _LOGGER.debug(' Start "step_init" '.center(60, "-"))
         _LOGGER.debug(">> user input: %s", user_input)
 
-        if user_input is not None:
-            lines_user_choose = user_input.get(CONF_LINES, [])
-
-            lines_new_state: list[Line] = []
-
-            for user_option in lines_user_choose:
-                (route_id, direction_id) = user_option.split("---")
-
-                lines_new_state.append(
-                    next(
-                        filter(
-                            lambda x: x.route_id == route_id
-                            and x.direction_id == direction_id,
-                            self._lines_available,
-                        )
-                    )
-                )
-
-            if lines_new_state == self._lines_selected:
-                _LOGGER.debug("No changes on entry configuration detected")
-                return self.async_abort(reason=CONF_ERROR_NO_CHANGES_OPTIONS)
-
-            return self.async_create_entry(
-                title="",
-                data={
-                    CONF_LINES: [x.to_dict() for x in lines_new_state],
-                },
-            )
+        await self._update_available_lines()
 
         options_list: list[SelectOptionDict] = [
             SelectOptionDict(
@@ -425,4 +404,46 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
                     )
                 }
             ),
+        )
+
+    async def _update_available_lines(self):
+        """Update config entry data with new available lines based on fetched stop times."""
+        stop_ids: list[str] = self.config_entry.data.get(CONF_STOP_IDS, [])
+        fetched_available_lines: list[Line] = []
+        api = MotisApi(base_url=REQUEST_API_URL)
+
+        for stop_id in stop_ids:
+            _LOGGER.debug("Fetching stop times for stop: %s", stop_id)
+
+            try:
+                stop_times = await _send_api_request(
+                    api,
+                    ApiCommand.STOP_TIMES,
+                    {
+                        "stopId": str(stop_id),
+                        "n": str(1000),
+                    },
+                )
+
+                fetched_available_lines.extend(
+                    _extract_lines_from_stop_times(stop_times)
+                )
+            except ValueError as err:
+                _LOGGER.error(
+                    "Error fetching stop times for stop %s: %s, continuing with next stop if available",
+                    stop_id,
+                    err,
+                )
+
+        self._lines_available.extend(fetched_available_lines)
+        self._lines_available = list(set(self._lines_available))  # remove duplicates
+
+        _LOGGER.debug("Updating config entry data with (new) available lines")
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={
+                **self.config_entry.data,
+                CONF_LINES: [x.to_dict() for x in self._lines_available],
+            },
         )

--- a/custom_components/ha_departures/coordinator.py
+++ b/custom_components/ha_departures/coordinator.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from aiohttp import ClientResponseError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api.data_classes import ApiCommand, Departure
@@ -51,7 +52,7 @@ class DeparturesDataUpdateCoordinator(DataUpdateCoordinator[list[Departure]]):
         self._lines_count: int = len(config_entry.options.get(CONF_LINES, []))
         self._data: list[Departure] = []
 
-        self._client = MotisApi(REQUEST_API_URL)
+        self._client = MotisApi(REQUEST_API_URL, async_get_clientsession(hass))
 
     @property
     def stop_coord(self) -> tuple:

--- a/custom_components/ha_departures/sensor.py
+++ b/custom_components/ha_departures/sensor.py
@@ -169,6 +169,7 @@ class DeparturesSensor(
         if not departures:
             self._attr_extra_state_attributes.update({ATTR_TIMES: []})
             self.async_write_ha_state()
+            self._value = None
 
             return
 


### PR DESCRIPTION
- fetch available lines before start options flow
- unset value of sensor if no departures delivered
- use hass session for coordinator requests