### PR TITLE
feat: implement Motis API client for network requests.

### DIFF
--- a/custom_components/ha_departures/api/motis_api.py
+++ b/custom_components/ha_departures/api/motis_api.py
@@ -101,9 +101,12 @@ class MotisApi:
 
         for attempt in range(retry + 1):
             try:
-                session = self.session or ClientSession()
+                if self.session:
+                    return await self.__send_get_request(
+                        url, self.session, headers, _timeout, params
+                    )
 
-                async with session:
+                async with ClientSession() as session:
                     return await self.__send_get_request(
                         url, session, headers, _timeout, params
                     )


### PR DESCRIPTION
Was war das Problem:
async with session: verwendet die Session als Context Manager, was sie beim Verlassen des Blocks schließt. Wenn self.session die von HA bereitgestellte aiohttp-Session ist, darf man sie nicht schließen — HA braucht sie weiterhin.

Der Fix:
Wenn self.session vorhanden (HA-Session): direkt nutzen, kein async with
Wenn keine Session vorhanden: eigene ClientSession() erstellen und mit async with verwalten (wird korrekt geschlossen)