### PR TITLE
fix: strip _G suffix from stop IDs before calling stoptimes API

### DIFF
--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -91,7 +91,7 @@ async def _fetch_lines(stop_ids: list[str | Stop], unique: bool = True) -> list[
                 api,
                 ApiCommand.STOP_TIMES,
                 {
-                    "stopId": str(stop_id),
+                    "stopId": str(stop_id).removesuffix("_G"),
                     "n": str(1000),
                 },
             )

--- a/custom_components/ha_departures/coordinator.py
+++ b/custom_components/ha_departures/coordinator.py
@@ -98,7 +98,7 @@ class DeparturesDataUpdateCoordinator(DataUpdateCoordinator[list[Departure]]):
 
         # Take only first stop_id and use "radius" parameter
         # to decrease amount of requests to the server
-        stop_id = self._stop_ids[0]
+        stop_id = self._stop_ids[0].removesuffix("_G")
 
         PARAMS = {
             "stopId": stop_id,
@@ -125,11 +125,12 @@ class DeparturesDataUpdateCoordinator(DataUpdateCoordinator[list[Departure]]):
     def _process_data(self, api_response: dict) -> list[Departure]:
         """Process data in a separate thread to avoid blocking the event loop."""
         departures = []
+        stop_ids_normalized = {s.removesuffix("_G") for s in self.stop_ids}
 
         for stop_time in api_response.get("stopTimes", []):
             departure = Departure.from_dict(stop_time)
 
-            if departure not in api_response and departure.stop_id in self.stop_ids:
+            if departure not in departures and departure.stop_id in stop_ids_normalized:
                 departures.append(departure)
 
         return departures


### PR DESCRIPTION
## Summary

- The Motis `stoptimes` API returns HTTP 404 when called with group stop IDs ending in `_G` (e.g. `de-DELFI_de:09261:64:2:4_G`)
- Strip the `_G` suffix in `config_flow.py` (`_fetch_lines`) and `coordinator.py` (`__fetch_data`) before making API requests
- Normalize stored stop IDs (strip `_G`) when filtering departures in `_process_data` so departures are not silently dropped
- Also fix an incorrect duplicate check in `_process_data`: was comparing `departure not in api_response` (dict) instead of `departure not in departures` (list)

## Root Cause

The `v1/map/stops` endpoint returns both plain stop IDs and group stop IDs with `_G` suffix for the same physical stop (e.g. `de-DELFI_de:09261:64:2:4` and `de-DELFI_de:09261:64:2:4_G`). When the first stored stop ID happens to be a `_G` variant, all API calls to `stoptimes` fail with HTTP 404.

## Test plan

- [ ] Configure integration with a stop that has `_G` stop IDs (e.g. German DELFI stops)
- [ ] Verify no more HTTP 404 errors in the HA logs
- [ ] Verify departures are fetched and displayed correctly