### PR TITLE
fix: restore options flow after Transitous API route ID format change

### DIFF
--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -435,16 +435,23 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
             for line in self._lines_available
         ]
 
+        available_values = {
+            f"{line.route_id}---{line.direction_id}"
+            for line in self._lines_available
+        }
+        valid_defaults = [
+            f"{x.route_id}---{x.direction_id}"
+            for x in self._lines_selected
+            if f"{x.route_id}---{x.direction_id}" in available_values
+        ]
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
                         "lines",
-                        default=[
-                            f"{x.route_id}---{x.direction_id}"
-                            for x in self._lines_selected
-                        ],
+                        default=valid_defaults,
                     ): SelectSelector(
                         SelectSelectorConfig(
                             options=options_list,

--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -439,11 +439,24 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
             f"{line.route_id}---{line.direction_id}"
             for line in self._lines_available
         }
-        valid_defaults = [
-            f"{x.route_id}---{x.direction_id}"
-            for x in self._lines_selected
-            if f"{x.route_id}---{x.direction_id}" in available_values
-        ]
+        valid_defaults = []
+        for old_line in self._lines_selected:
+            value = f"{old_line.route_id}---{old_line.direction_id}"
+            if value in available_values:
+                valid_defaults.append(value)
+            else:
+                # Try suffix match to migrate old route ID format (e.g. missing de-DELFI_ prefix)
+                migrated = next(
+                    (
+                        f"{line.route_id}---{line.direction_id}"
+                        for line in self._lines_available
+                        if line.route_id.endswith(old_line.route_id)
+                        and line.direction_id == old_line.direction_id
+                    ),
+                    None,
+                )
+                if migrated:
+                    valid_defaults.append(migrated)
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -91,7 +91,7 @@ async def _fetch_lines(stop_ids: list[str | Stop], unique: bool = True) -> list[
                 api,
                 ApiCommand.STOP_TIMES,
                 {
-                    "stopId": str(stop_id),
+                    "stopId": str(stop_id).removesuffix("_G"),
                     "n": str(1000),
                 },
             )

--- a/custom_components/ha_departures/coordinator.py
+++ b/custom_components/ha_departures/coordinator.py
@@ -98,7 +98,7 @@ class DeparturesDataUpdateCoordinator(DataUpdateCoordinator[list[Departure]]):
 
         # Take only first stop_id and use "radius" parameter
         # to decrease amount of requests to the server
-        stop_id = self._stop_ids[0]
+        stop_id = self._stop_ids[0].removesuffix("_G")
 
         PARAMS = {
             "stopId": stop_id,
@@ -125,11 +125,12 @@ class DeparturesDataUpdateCoordinator(DataUpdateCoordinator[list[Departure]]):
     def _process_data(self, api_response: dict) -> list[Departure]:
         """Process data in a separate thread to avoid blocking the event loop."""
         departures = []
+        stop_ids_normalized = {s.removesuffix("_G") for s in self.stop_ids}
 
         for stop_time in api_response.get("stopTimes", []):
             departure = Departure.from_dict(stop_time)
 
-            if departure not in api_response and departure.stop_id in self.stop_ids:
+            if departure not in departures and departure.stop_id in stop_ids_normalized:
                 departures.append(departure)
 
         return departures


### PR DESCRIPTION
## Background

PR #183 (included in v3.1.3) fixed the HTTP 404 errors by stripping the `_G` suffix from stop IDs before calling the `stoptimes` API. However, this only resolved the **log errors** — the options flow (edit mode of an existing integration entry) remained broken due to a second API change.

## Root Cause

The Transitous API changed the format of route IDs at some point:

| | Route ID format |
|---|---|
| Old (stored in config) | `1960465_106` |
| New (returned by API) | `de-DELFI_1960465_106` |

Note: PR #185 already fixed this for the **sensor** (departure display) using `endswith` matching. This PR applies the same principle to the **options flow**.

## Problem

When a user opens the edit form of an existing entry, the options flow fetches fresh lines from the API (new format) but tries to pre-select the previously saved lines (old format). Since old and new IDs don't match:

1. HA throws a validation error: `value must be one of ['de-DELFI_1960465_106---0', ...]`
2. The pre-selected lines appear as raw IDs (`1960465_106--1`) instead of proper names

## Changes (`config_flow.py`)

- Filter pre-selected defaults to only include values that exist in the available options (prevents the HA validation error)
- Auto-migrate old route IDs to new format via suffix matching — consistent with the `endswith` approach already used in `sensor.py` (#185)

## Result

Existing configurations are automatically migrated when the user opens the edit form. Previously selected lines appear pre-selected with correct names — no manual re-selection needed.

## Test plan

- [x] Install v3.1.3, configure integration with a German DELFI stop
- [x] Open the options/edit form → previously selected lines should appear with correct names
- [x] Verify no validation errors when saving