### PR TITLE
fix: restore options flow after Transitous API route ID format change

### DIFF
--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -435,16 +435,23 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
             for line in self._lines_available
         ]
 
+        available_values = {
+            f"{line.route_id}---{line.direction_id}"
+            for line in self._lines_available
+        }
+        valid_defaults = [
+            f"{x.route_id}---{x.direction_id}"
+            for x in self._lines_selected
+            if f"{x.route_id}---{x.direction_id}" in available_values
+        ]
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
                         "lines",
-                        default=[
-                            f"{x.route_id}---{x.direction_id}"
-                            for x in self._lines_selected
-                        ],
+                        default=valid_defaults,
                     ): SelectSelector(
                         SelectSelectorConfig(
                             options=options_list,

--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -439,11 +439,24 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
             f"{line.route_id}---{line.direction_id}"
             for line in self._lines_available
         }
-        valid_defaults = [
-            f"{x.route_id}---{x.direction_id}"
-            for x in self._lines_selected
-            if f"{x.route_id}---{x.direction_id}" in available_values
-        ]
+        valid_defaults = []
+        for old_line in self._lines_selected:
+            value = f"{old_line.route_id}---{old_line.direction_id}"
+            if value in available_values:
+                valid_defaults.append(value)
+            else:
+                # Try suffix match to migrate old route ID format (e.g. missing de-DELFI_ prefix)
+                migrated = next(
+                    (
+                        f"{line.route_id}---{line.direction_id}"
+                        for line in self._lines_available
+                        if line.route_id.endswith(old_line.route_id)
+                        and line.direction_id == old_line.direction_id
+                    ),
+                    None,
+                )
+                if migrated:
+                    valid_defaults.append(migrated)
 
         return self.async_show_form(
             step_id="init",


### PR DESCRIPTION
## Background

PR #183 (v3.1.3) fixed the HTTP 404 errors by stripping the `_G` suffix from stop IDs. PR #185 fixed departure display in the sensor using `endswith` matching. However, the **options flow** (edit mode of an existing entry) remained broken.

## Root Cause

The Transitous API changed the format of route IDs:

| | Route ID format |
|---|---|
| Old (stored in config) | `1960465_106` |
| New (returned by API) | `de-DELFI_1960465_106` |

When opening the edit form, the options flow fetches fresh lines (new format) but tries to pre-select previously saved lines (old format). Since old and new IDs don't match:

1. HA throws a validation error: `value must be one of ['de-DELFI_1960465_106---0', ...]`
2. Pre-selected lines appear as raw IDs (`1960465_106--1`) instead of proper names

## Changes (`config_flow.py` only)

- Filter pre-selected defaults to only include values that exist in the available options (prevents the HA validation error)
- Auto-migrate old route IDs to new format via suffix matching — consistent with the `endswith` approach already used in `sensor.py` (#185)

## Result

Existing configurations are automatically migrated when the user opens the edit form. Previously selected lines appear pre-selected with correct names — no manual re-selection needed.

## Test plan

- [x] Install v3.1.3, configure integration with a German DELFI stop
- [x] Open the options/edit form → previously selected lines should appear with correct names
- [x] Verify no validation errors when saving