### PR TITLE
feat: add scheduled_track and track to departure attributes

### DIFF
--- a/custom_components/ha_departures/api/data_classes.py
+++ b/custom_components/ha_departures/api/data_classes.py
@@ -170,6 +170,8 @@ class Departure:
     cancelled: bool = False
     trip_cancelled: bool = False
     alerts: bool = False
+    scheduled_track: str | None = None
+    track: str | None = None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "Departure":
@@ -191,6 +193,8 @@ class Departure:
             cancelled=data.get("cancelled", False),
             trip_cancelled=data.get("tripCancelled", False),
             alerts=bool(alerts),
+            scheduled_track=data.get("place", {}).get("scheduledTrack"),
+            track=data.get("place", {}).get("track"),
         )
 
     def __hash__(self) -> int:

--- a/custom_components/ha_departures/const.py
+++ b/custom_components/ha_departures/const.py
@@ -49,6 +49,8 @@ ATTR_TRIP_ID: Final = "trip_id"
 ATTR_DEPARTURE_CANCELLED: Final = "cancelled"
 ATTR_HEAD_SIGN: Final = "head_sign"
 ATTR_DEPARTURE_ALERTS: Final = "alerts"
+ATTR_SCHEDULED_TRACK: Final = "scheduled_track"
+ATTR_TRACK: Final = "track"
 
 DEPARTURES_PER_SENSOR_LIMIT: Final = 10  # max number of departures per sensor
 

--- a/custom_components/ha_departures/sensor.py
+++ b/custom_components/ha_departures/sensor.py
@@ -19,7 +19,9 @@ from .const import (
     ATTR_LINE_NAME,
     ATTR_PLANNED_DEPARTURE_TIME,
     ATTR_PROVIDER_URL,
+    ATTR_SCHEDULED_TRACK,
     ATTR_TIMES,
+    ATTR_TRACK,
     ATTR_TRANSPORT_TYPE,
     ATTR_TRIP_ID,
     CONF_LINES,
@@ -201,6 +203,8 @@ class DeparturesSensor(
                         ATTR_DEPARTURE_CANCELLED: d.cancelled,
                         ATTR_HEAD_SIGN: d.head_sign,
                         ATTR_DEPARTURE_ALERTS: d.alerts,
+                        ATTR_SCHEDULED_TRACK: d.scheduled_track,
+                        ATTR_TRACK: d.track,
                     }
                     for d in departures
                 ],


### PR DESCRIPTION
## Summary

Exposes the platform/track information from the Motis `stoptimes` API response as new departure attributes.

## Background

The `_G` group stop fix in v3.1.3 (#183) means the integration now works with proper platform stops instead of virtual group stops. These platform stops include `scheduledTrack` and `track` fields in the API response — data that was previously unavailable because `_G` stops don't have platform information.

## New attributes (per departure in `times`)

| Attribute | Description | Example |
|---|---|---|
| `scheduled_track` | Planned platform/track | `"4+5"`, `"20"`, `"Bus Ost 1-10"` |
| `track` | Real-time platform/track | May differ from `scheduled_track` on platform changes |

Both fields are `null` when the API provides no track information.

## Changes

- `api/data_classes.py` — add `scheduled_track` and `track` fields to `Departure` dataclass and parse from `place.scheduledTrack` / `place.track`
- `const.py` — add `ATTR_SCHEDULED_TRACK` and `ATTR_TRACK` constants
- `sensor.py` — include new attributes in the `times` list output

## Test plan

- [x] Configure integration with a stop that has platform information (e.g. train station)
- [x] Verify `scheduled_track` and `track` appear in sensor attributes under `times`
- [x] Verify both fields are `null` for stops without track info (e.g. some bus stops)