### PR TITLE
feat: add exponential backoff and transient error handling to API retries

### DIFF
--- a/custom_components/ha_departures/api/motis_api.py
+++ b/custom_components/ha_departures/api/motis_api.py
@@ -59,16 +59,11 @@ class MotisApi:
         logger.debug("Request headers: %s", headers)
         logger.debug("Request timeout: %s", timeout)
 
-        try:
-            async with session.get(
-                url, params=params, headers=headers, timeout=timeout
-            ) as response:
-                response.raise_for_status()
-                return await response.json()
-        except ClientResponseError:
-            raise
-        except (ClientError, ClientSSLError):
-            raise
+        async with session.get(
+            url, params=params, headers=headers, timeout=timeout
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
 
     async def get(
         self,

--- a/custom_components/ha_departures/api/motis_api.py
+++ b/custom_components/ha_departures/api/motis_api.py
@@ -1,5 +1,6 @@
 """Motis API client."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -20,6 +21,8 @@ from custom_components.ha_departures.const import (
 from .data_classes import ApiCommand
 
 logger = logging.getLogger(__name__)
+
+TRANSIENT_STATUS_CODES = {429, 500, 502, 503, 504}
 
 
 class MotisApi:
@@ -63,10 +66,8 @@ class MotisApi:
                 response.raise_for_status()
                 return await response.json()
         except ClientResponseError as e:
-            logger.error("HTTP error %s for URL: %s", e.status, url)
             raise
         except (ClientError, ClientSSLError) as e:
-            logger.error("Network error for URL: %s; Error: %s", url, str(e))
             raise
 
     async def get(
@@ -110,15 +111,27 @@ class MotisApi:
                     return await self.__send_get_request(
                         url, session, headers, _timeout, params
                     )
-            except (ClientResponseError, ClientError, ClientSSLError):
-                if attempt < retry:
+            except ClientResponseError as e:
+                if attempt < retry and e.status in TRANSIENT_STATUS_CODES:
+                    wait = 5 * (2 ** attempt)  # 5s, 10s, 20s
                     logger.debug(
-                        "Retrying request to '%s' (attempt %d of %d)",
-                        url,
-                        attempt + 1,
-                        retry,
+                        "Retrying request to '%s' in %ds (attempt %d of %d)",
+                        url, wait, attempt + 1, retry,
                     )
+                    await asyncio.sleep(wait)
                 else:
+                    logger.error("Request to '%s' failed after %d attempt(s): %s", url, retry + 1, str(e))
+                    raise
+            except (ClientError, ClientSSLError) as e:
+                if attempt < retry:
+                    wait = 5 * (2 ** attempt)  # 5s, 10s, 20s
+                    logger.debug(
+                        "Retrying request to '%s' in %ds (attempt %d of %d)",
+                        url, wait, attempt + 1, retry,
+                    )
+                    await asyncio.sleep(wait)
+                else:
+                    logger.error("Request to '%s' failed after %d attempt(s): %s", url, retry + 1, str(e))
                     raise
 
         return (

--- a/custom_components/ha_departures/api/motis_api.py
+++ b/custom_components/ha_departures/api/motis_api.py
@@ -65,9 +65,9 @@ class MotisApi:
             ) as response:
                 response.raise_for_status()
                 return await response.json()
-        except ClientResponseError as e:
+        except ClientResponseError:
             raise
-        except (ClientError, ClientSSLError) as e:
+        except (ClientError, ClientSSLError):
             raise
 
     async def get(


### PR DESCRIPTION
## Summary

Improves the existing retry mechanism in `MotisApi` to handle transient network and server errors more gracefully.

## Problem

The current retry logic retries immediately without any delay. For DNS timeouts (e.g. router restart at night) or server errors (502/503), immediate retries fail just as fast — all attempts are exhausted within milliseconds and an error appears in HA logs.

## Changes

- **Exponential backoff** — waits 5s → 10s → 20s between retries, giving DNS and servers time to recover (max 35s, fits within the 60s update interval)
- **Transient-only retries** — only retries on `429`, `500`, `502`, `503`, `504` and network errors (DNS timeout, connection reset). Non-transient errors like `404` or `400` are raised immediately.
- **Reduced log noise** — errors are only logged after the final failed attempt. If a retry succeeds, nothing is logged at all.

## Before / After

**Before:** 3 retries with no delay → 4 error log entries within seconds  
**After:** 3 retries with 5s/10s/20s delay → 0 log entries if retry succeeds, 1 error entry if all fail