### PR TITLE
fix(config_flow): show human-readable line names in options chips

### DIFF
--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -119,7 +119,7 @@ def _build_line_options(
     options: list[SelectOptionDict] = []
     seen: Counter[str] = Counter()
 
-    for line, base in zip(lines, base_keys):
+    for line, base in zip(lines, base_keys, strict=True):
         if base_counts[base] == 1:
             key = base
         else:
@@ -283,9 +283,9 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             selected_lines: list[Line] = [
-                self._line_map[key]
+                line
                 for key in user_input.get(CONF_LINES, [])
-                if key in self._line_map
+                if (line := self._line_map.get(key)) is not None
             ]
 
             if not selected_lines:
@@ -393,9 +393,9 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             lines_new_state: list[Line] = [
-                self._line_map[key]
+                line
                 for key in user_input.get(CONF_LINES, [])
-                if key in self._line_map
+                if (line := self._line_map.get(key)) is not None
             ]
 
             if lines_new_state == self._lines_selected:

--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -112,21 +112,19 @@ def _build_line_options(
     lines: list[Line],
 ) -> tuple[list[SelectOptionDict], dict[str, Line]]:
     """Build SelectOptionDict list and a value→Line map with human-readable values."""
-    base_keys = [f"{l.route_short_name} - {l.head_sign}" for l in lines]
+    base_keys = [f"{line.route_short_name} - {line.head_sign}" for line in lines]
     base_counts = Counter(base_keys)
 
     line_map: dict[str, Line] = {}
     options: list[SelectOptionDict] = []
-    seen: Counter = Counter()
+    seen: Counter[str] = Counter()
 
     for line, base in zip(lines, base_keys):
         if base_counts[base] == 1:
             key = base
         else:
-            key = base
-            seen[key] += 1
-            if seen[key] > 1:
-                key = f"{base} ({seen[key]})"
+            seen[base] += 1
+            key = base if seen[base] == 1 else f"{base} ({seen[base]})"
         line_map[key] = line
         options.append(SelectOptionDict(label=key, value=key))
 

--- a/custom_components/ha_departures/config_flow.py
+++ b/custom_components/ha_departures/config_flow.py
@@ -1,6 +1,7 @@
 """Adds config flow for Public Transport Departures."""
 
 import logging
+from collections import Counter
 from typing import Any
 
 import homeassistant.helpers.config_validation as cv
@@ -107,6 +108,31 @@ async def _fetch_lines(stop_ids: list[str | Stop], unique: bool = True) -> list[
     return list(set(lines)) if unique else lines
 
 
+def _build_line_options(
+    lines: list[Line],
+) -> tuple[list[SelectOptionDict], dict[str, Line]]:
+    """Build SelectOptionDict list and a value→Line map with human-readable values."""
+    base_keys = [f"{l.route_short_name} - {l.head_sign}" for l in lines]
+    base_counts = Counter(base_keys)
+
+    line_map: dict[str, Line] = {}
+    options: list[SelectOptionDict] = []
+    seen: Counter = Counter()
+
+    for line, base in zip(lines, base_keys):
+        if base_counts[base] == 1:
+            key = base
+        else:
+            key = base
+            seen[key] += 1
+            if seen[key] > 1:
+                key = f"{base} ({seen[key]})"
+        line_map[key] = line
+        options.append(SelectOptionDict(label=key, value=key))
+
+    return options, line_map
+
+
 class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for ha_departures."""
 
@@ -120,6 +146,7 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._stop = None
         self._selected_stops: list[Stop] = []
         self._lines: list[Line] = []
+        self._line_map: dict[str, Line] = {}
         self._data: dict[str, Any] = {}
         self._options: dict[str, Any] = {}
         self._api = MotisApi(base_url=REQUEST_API_URL)
@@ -257,21 +284,11 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug(">> user input: %s", user_input)
 
         if user_input is not None:
-            selected_lines: list[Line] = []
-
-            for line in user_input.get(CONF_LINES, []):
-                (routeId, directionId) = line.split("---")
-
-                selected_lines.append(
-                    next(
-                        filter(
-                            lambda x: (
-                                x.route_id == routeId and x.direction_id == directionId
-                            ),
-                            self._lines,
-                        )
-                    )
-                )
+            selected_lines: list[Line] = [
+                self._line_map[key]
+                for key in user_input.get(CONF_LINES, [])
+                if key in self._line_map
+            ]
 
             if not selected_lines:
                 _errors[CONF_LINES] = CONF_ERROR_NO_LINE_SELECTED
@@ -290,14 +307,7 @@ class DeparturesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_hubname()
 
         self._lines = await _fetch_lines(self._selected_stops, unique=True)
-
-        line_list: list[SelectOptionDict] = [
-            SelectOptionDict(
-                label=f"{line.route_short_name} - {line.head_sign}",
-                value=f"{line.route_id}---{line.direction_id}",
-            )
-            for line in self._lines
-        ]
+        line_list, self._line_map = _build_line_options(self._lines)
 
         return self.async_show_form(
             step_id="lines",
@@ -373,6 +383,7 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
         self._lines_available: list[Line] = [
             Line.from_dict(x) for x in config_entry.data.get(CONF_AVAILABLE_LINES, [])
         ]
+        self._line_map: dict[str, Line] = {}
 
         _LOGGER.debug("Start configuration")
 
@@ -383,24 +394,11 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
         _LOGGER.debug(">> user input: %s", user_input)
 
         if user_input is not None:
-            lines_user_choose = user_input.get(CONF_LINES, [])
-
-            lines_new_state: list[Line] = []
-
-            for user_option in lines_user_choose:
-                (route_id, direction_id) = user_option.split("---")
-
-                lines_new_state.append(
-                    next(
-                        filter(
-                            lambda x: (
-                                x.route_id == route_id
-                                and x.direction_id == direction_id
-                            ),
-                            self._lines_available,
-                        )
-                    )
-                )
+            lines_new_state: list[Line] = [
+                self._line_map[key]
+                for key in user_input.get(CONF_LINES, [])
+                if key in self._line_map
+            ]
 
             if lines_new_state == self._lines_selected:
                 _LOGGER.debug("No changes on entry configuration detected")
@@ -427,36 +425,33 @@ class DeparturesOptionsFlowHandler(config_entries.OptionsFlow):
             },
         )
 
-        options_list: list[SelectOptionDict] = [
-            SelectOptionDict(
-                label=f"{line.route_short_name} - {line.head_sign}",
-                value=f"{line.route_id}---{line.direction_id}",
-            )
-            for line in self._lines_available
-        ]
+        options_list, self._line_map = _build_line_options(self._lines_available)
 
-        available_values = {
-            f"{line.route_id}---{line.direction_id}"
-            for line in self._lines_available
+        # Compute pre-selected defaults by matching stored lines against the new map.
+        # Falls back to suffix match to migrate old route ID formats.
+        available_by_id = {
+            (line.route_id, line.direction_id): line for line in self._lines_available
         }
         valid_defaults = []
         for old_line in self._lines_selected:
-            value = f"{old_line.route_id}---{old_line.direction_id}"
-            if value in available_values:
-                valid_defaults.append(value)
-            else:
-                # Try suffix match to migrate old route ID format (e.g. missing de-DELFI_ prefix)
-                migrated = next(
+            matched = available_by_id.get((old_line.route_id, old_line.direction_id))
+            if matched is None:
+                # suffix match for migrated route IDs
+                matched = next(
                     (
-                        f"{line.route_id}---{line.direction_id}"
+                        line
                         for line in self._lines_available
                         if line.route_id.endswith(old_line.route_id)
                         and line.direction_id == old_line.direction_id
                     ),
                     None,
                 )
-                if migrated:
-                    valid_defaults.append(migrated)
+            if matched is not None:
+                key = next(
+                    (k for k, v in self._line_map.items() if v == matched), None
+                )
+                if key:
+                    valid_defaults.append(key)
 
         return self.async_show_form(
             step_id="init",


### PR DESCRIPTION
## Summary

I thought we had already fixed this in #187, but it turns out that PR addressed a different issue (route-ID format migration). The label display problem in the options dialog was still present.

The options dialog displayed already-selected lines as raw internal IDs (e.g. `6021032_106---0`, `de:mvv-muenchen:60-627|627|StadtBus:1069_3---0`) instead of the line name (e.g. `RE2 - München Hbf`).

### Why this only affected existing configurations

HA's `SelectSelector` in DROPDOWN mode renders selected chips using the option's label only when the selector can resolve the default value against its options at render time. For a brand-new selection the user just made in the same session, the label is shown. But when the options flow is reopened later, the persisted values are passed in as defaults and rendered as raw value strings — which in our case were the opaque `{route_id}---{direction_id}` keys.

### Fix

- Use the human-readable label (`route_short_name - head_sign`) as **both** the `SelectOption` label and its value.
- A `_line_map: dict[str, Line]` on the flow handler keeps the value→Line mapping so the submit handler can resolve the user's selection back to concrete `Line` objects.
- Collisions are handled with a counter suffix (`(2)`, `(3)`, …) when two lines share the same `route_short_name - head_sign` (e.g. two `RE22 - Flughafen München` variants with different `route_id`s). This avoids overwriting entries in the line map and keeps disambiguation human-friendly.
- The route-ID-suffix migration from #187 is preserved when computing the pre-selected defaults for the options form.

Please double-check the logic — especially the collision handling and the defaults resolution in the options flow.

## Test plan

- [ ] Open options dialog on an existing config entry → chips show line names like `RE2 - München Hbf` instead of raw IDs.
- [ ] Add a new line, save, reopen options → still shows readable names.
- [ ] Stop with two distinct lines that share `route_short_name - head_sign` → both appear, second labeled `… (2)`.
- [ ] Existing config entry with old route-ID format → suffix-migration still resolves defaults correctly.
- [ ] Initial configuration flow (new entry) → line picker also shows readable names.